### PR TITLE
Update dependency block in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Spandex is a platform agnostic tracing library. Currently there is only a datado
 ## Installation
 ```elixir
 def deps do
-  [{:spandex, ~> "1.1.0"}]
+  [{:spandex, "~> 1.1.0"}]
 end
 ```
 


### PR DESCRIPTION
The leading quote around the dependency version was in the wrong location.