### PR TITLE
Distributed Tracing

### DIFF
--- a/lib/adapters/adapter.ex
+++ b/lib/adapters/adapter.ex
@@ -17,4 +17,5 @@ defmodule Spandex.Adapters.Adapter do
   @callback continue_trace_from_span(String.t, map) :: {:ok, term} | {:error, term}
   @callback update_top_span(map) :: :ok | {:error, term}
   @callback update_all_spans(map) :: :ok | {}
+  @callback distributed_context(Plug.Conn.t) :: {:ok, term} | {:error, term}
 end

--- a/lib/adapters/datadog.ex
+++ b/lib/adapters/datadog.ex
@@ -264,10 +264,10 @@ defmodule Spandex.Adapters.Datadog do
     trace_id = Helpers.get_first_header(conn, "x-datadog-trace-id")
     parent_id = Helpers.get_first_header(conn, "x-datadog-parent-id")
 
-    if !is_nil(trace_id) && !is_nil(parent_id) do
-      {:ok, %{trace_id: trace_id, parent_id: parent_id}}
-    else
+    if is_nil(trace_id) || is_nil(parent_id) do
       {:error, :no_distributed_trace}
+    else
+      {:ok, %{trace_id: trace_id, parent_id: parent_id}}
     end
   end
 

--- a/lib/adapters/datadog.ex
+++ b/lib/adapters/datadog.ex
@@ -5,6 +5,7 @@ defmodule Spandex.Adapters.Datadog do
 
   @behaviour Spandex.Adapters.Adapter
 
+  alias Spandex.Adapters.Helpers
   alias Spandex.Datadog.Api
   alias Spandex.Datadog.Span
   alias Spandex.Datadog.Utils
@@ -18,6 +19,7 @@ defmodule Spandex.Adapters.Datadog do
   def start_trace(name) do
     if get_trace() do
       Logger.error("Tried to start a trace over top of another trace.")
+      {:error, :trace_running}
     else
       trace_id = Utils.next_id()
       top_span =
@@ -251,6 +253,22 @@ defmodule Spandex.Adapters.Datadog do
     stacktrace = Exception.format_stacktrace(System.stacktrace)
 
     update_span(%{error: 1, error_message: message, stacktrace: stacktrace, error_type: type})
+  end
+
+  @doc """
+  Fetches the datadog trace & parent IDs from the conn request headers
+  if they are present.
+  """
+  @spec distributed_context(conn :: Plug.Conn.t) :: {:ok, %{trace_id: binary, parent_id: binary}} | {:error, :no_trace_context}
+  def distributed_context(%Plug.Conn{} = conn) do
+    trace_id = Helpers.get_first_header(conn, "x-datadog-trace-id")
+    parent_id = Helpers.get_first_header(conn, "x-datadog-parent-id")
+
+    if !is_nil(trace_id) && !is_nil(parent_id) do
+      {:ok, %{trace_id: trace_id, parent_id: parent_id}}
+    else
+      {:error, :no_distributed_trace}
+    end
   end
 
   @spec get_trace(term) :: term

--- a/lib/adapters/helpers.ex
+++ b/lib/adapters/helpers.ex
@@ -35,4 +35,11 @@ defmodule Spandex.Adapters.Helpers do
 
     configured_level_position <= span_level_position
   end
+
+  @spec get_first_header(conn :: Plug.Conn.t, header_name :: binary) :: binary | nil
+  def get_first_header(conn, header_name) do
+    conn
+    |> Plug.Conn.get_req_header(header_name)
+    |> List.first()
+  end
 end

--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -98,4 +98,5 @@ defmodule Spandex do
   delegate_to_adapter(:current_trace_id, [])
   delegate_to_adapter(:current_span_id, [])
   delegate_to_adapter(:current_span, [])
+  delegate_to_adapter(:distributed_context, [conn])
 end

--- a/test/plug/start_trace_test.exs
+++ b/test/plug/start_trace_test.exs
@@ -75,13 +75,13 @@ defmodule Spandex.Plug.StartTraceTest do
       conn =
         conn
         |> Plug.Conn.put_req_header("x-datadog-trace-id", "12345")
-        |> Plug.Conn.put_req_header("x-datadog-parent-id", "12345")
+        |> Plug.Conn.put_req_header("x-datadog-parent-id", "67890")
 
       new_conn = StartTrace.call(conn, [])
 
-      assert %{trace_id: "12345", parent_id: "12345"} = Spandex.current_span()
+      assert %{trace_id: "12345", parent_id: "67890"} = Spandex.current_span()
 
-      refute Spandex.current_span_id() == "12345"
+      refute Spandex.current_span_id() == "67890"
       refute is_nil(Spandex.current_span_id())
 
       assert new_conn.assigns[:spandex_trace_request?]

--- a/test/plug/start_trace_test.exs
+++ b/test/plug/start_trace_test.exs
@@ -71,6 +71,22 @@ defmodule Spandex.Plug.StartTraceTest do
       end
     end
 
+    test "continues existing trace when distributed context exists", %{conn: conn} do
+      conn =
+        conn
+        |> Plug.Conn.put_req_header("x-datadog-trace-id", "12345")
+        |> Plug.Conn.put_req_header("x-datadog-parent-id", "12345")
+
+      new_conn = StartTrace.call(conn, [])
+
+      assert %{trace_id: "12345", parent_id: "12345"} = Spandex.current_span()
+
+      refute Spandex.current_span_id() == "12345"
+      refute is_nil(Spandex.current_span_id())
+
+      assert new_conn.assigns[:spandex_trace_request?]
+    end
+
     test "starts new trace", %{conn: conn} do
       new_conn = StartTrace.call(conn, [])
 


### PR DESCRIPTION
Adds support for distributed tracing using the `x-datadog-trace-id` and `x-datadog-parent-id` as discussed in https://github.com/zachdaniel/spandex/issues/6.