### PR TITLE
Parse datadog distributed headers properly

### DIFF
--- a/lib/adapters/datadog.ex
+++ b/lib/adapters/datadog.ex
@@ -248,7 +248,7 @@ defmodule Spandex.Adapters.Datadog do
   """
   @impl Spandex.Adapters.Adapter
   @spec continue_trace(String.t(), term, term, Keyword.t()) :: {:ok, term} | {:error, term}
-  def continue_trace(name, trace_id, span_id, opts) do
+  def continue_trace(name, trace_id, span_id, opts) when is_integer(trace_id) and is_integer(span_id) do
     trace = get_trace(:undefined)
 
     cond do
@@ -306,7 +306,17 @@ defmodule Spandex.Adapters.Datadog do
     conn
     |> Plug.Conn.get_req_header(header_name)
     |> List.first()
+    |> parse_header()
   end
+
+  defp parse_header(<< header :: binary >>) do
+    case Integer.parse(header) do
+      {int, _} -> int
+      _        -> nil
+    end
+  end
+
+  defp parse_header(_header), do: nil
 
   @spec get_trace(term) :: term
   defp get_trace(default \\ nil) do

--- a/lib/adapters/datadog.ex
+++ b/lib/adapters/datadog.ex
@@ -309,7 +309,7 @@ defmodule Spandex.Adapters.Datadog do
     |> parse_header()
   end
 
-  defp parse_header(<< header :: binary >>) do
+  defp parse_header(header) when is_bitstring(header) do
     case Integer.parse(header) do
       {int, _} -> int
       _        -> nil

--- a/test/plug/start_trace_test.exs
+++ b/test/plug/start_trace_test.exs
@@ -99,9 +99,9 @@ defmodule Spandex.Plug.StartTraceTest do
 
       new_conn = StartTrace.call(conn, ignored_routes: [], ignored_methods: [], tracer: Tracer)
 
-      assert %{trace_id: "12345", parent_id: "67890"} = Tracer.current_span()
+      assert %{trace_id: 12345, parent_id: 67890} = Tracer.current_span()
 
-      refute Tracer.current_span_id() == "67890"
+      refute Tracer.current_span_id() == 67890
       refute is_nil(Tracer.current_span_id())
 
       assert new_conn.assigns[:spandex_trace_request?]


### PR DESCRIPTION
I made a boo-boo in the original distributed tracing; datadog expects the trace ID and parent span ID to be integers (i.e. not in string format). As headers are strings across the network, we need to parse 'em back out to integers. Have tested this now and am seeing lovely distributed traces.