### PR TITLE
Add Benchee benchmarks for Plugs

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["mix.exs", "{benchmarks,config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ script:
   - mix credo
   - mix coveralls.travis
 after_script:
-  - mix deps.get --only docs
-  - MIX_ENV=docs mix inch.report
+  - mix deps.get
+  - mix inch.report

--- a/benchmarks/plugs.exs
+++ b/benchmarks/plugs.exs
@@ -1,0 +1,98 @@
+Application.put_env(:benchmark, BenchmarkTracer, [
+  service: :benchmark_service,
+  adapter: Spandex.Adapters.Datadog,
+  disabled?: false,
+  env: to_string(Mix.env())
+])
+
+defmodule BenchmarkTracer do
+  use Spandex.Tracer, otp_app: :benchmark
+end
+
+defmodule Benchmarks.Plug do
+
+  defmodule BaselineRouter do
+    use Plug.Router
+
+    plug :match
+    plug :dispatch
+
+    get "/" do
+      resp(conn, 200, "OK")
+    end
+  end
+
+  defmodule StartEndRouter do
+    use Plug.Router
+
+    plug Spandex.Plug.StartTrace, tracer: BenchmarkTracer
+    plug :match
+    plug :dispatch
+    plug Spandex.Plug.EndTrace, tracer: BenchmarkTracer
+
+    get "/" do
+      resp(conn, 200, "OK")
+    end
+  end
+
+  defmodule AddContextRouter do
+    use Plug.Router
+
+    plug Spandex.Plug.StartTrace, tracer: BenchmarkTracer
+    plug :match
+    plug :dispatch
+    plug Spandex.Plug.AddContext, tracer: BenchmarkTracer
+    plug Spandex.Plug.EndTrace, tracer: BenchmarkTracer
+
+    get "/" do
+      resp(conn, 200, "OK")
+    end
+  end
+
+  def baseline(opts \\ []) do
+    call(BaselineRouter, :get, "/")
+  end
+
+  def start_end(opts \\ []) do
+    call(StartEndRouter, :get, "/")
+  end
+
+  def addcontext(opts \\ []) do
+    call(AddContextRouter, :get, "/")
+  end
+
+  defp call(router, method, path) do
+    method
+    |> Plug.Test.conn(path)
+    |> router.call(router.init([]))
+  end
+end
+
+{:ok, pid} = GenServer.start_link(
+  Spandex.Datadog.ApiServer,
+  [
+    host: "localhost",
+    port: 8126,
+    batch_size: 1000,
+    sync_threshold: 100,
+    http: HTTPoison
+  ],
+  name: Spandex.Datadog.ApiServer
+)
+
+HTTPoison.start
+
+Benchee.run(
+  %{
+    baseline: &Benchmarks.Plug.baseline/1,
+    start_finish: &Benchmarks.Plug.start_end/1,
+    addcontext: &Benchmarks.Plug.addcontext/1
+  },
+  time: 10,
+  memory_time: 2,
+  parallel: 4,
+  inputs: %{
+    no_sampling: [],
+    #sample_rate_100: [sample_rate: 100]
+  }
+)

--- a/benchmarks/support/adapter.ex
+++ b/benchmarks/support/adapter.ex
@@ -1,0 +1,24 @@
+defmodule Benchmark.Adapter do
+  @moduledoc """
+  Try to do as little work as possible here, so that authors of real adapters
+  can benchmark the performance of their libraries against this "null" one.
+  """
+  @behaviour Spandex.Adapter
+
+  require Logger
+
+  @impl Spandex.Adapter
+  def trace_id, do: 1234
+
+  @impl Spandex.Adapter
+  def span_id, do: trace_id()
+
+  @impl Spandex.Adapter
+  def now, do: :os.system_time(:nano_seconds)
+
+  @impl Spandex.Adapter
+  def default_sender, do: Benchmark.Sender
+
+  @impl Spandex.Adapter
+  def distributed_context(_conn, _opts), do: {:error, :no_distributed_trace}
+end

--- a/benchmarks/support/sender.ex
+++ b/benchmarks/support/sender.ex
@@ -1,0 +1,7 @@
+defmodule Benchmark.Sender do
+  @moduledoc """
+  Don't count the time it takes to send traces to a tracing back-end in our benchmarks. That would be accounted-for in
+  the Adapter library's benchmarks, if available.
+  """
+  def send_spans(spans), do: :ok
+end

--- a/benchmarks/support/tracer.ex
+++ b/benchmarks/support/tracer.ex
@@ -1,0 +1,4 @@
+defmodule Benchmark.Tracer do
+  @moduledoc false
+  use Spandex.Tracer, otp_app: :benchmark
+end

--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -91,6 +91,7 @@ defmodule Spandex.Tracer do
   def tracer_opts(), do: @all_tracer_opts
 
   defmacro __using__(opts) do
+    # credo:disable-for-next-line Credo.Check.Refactor.LongQuoteBlocks
     quote do
       @otp_app unquote(opts)[:otp_app] || raise("Must provide `otp_app` to `use Spandex.Tracer`")
 

--- a/mix.exs
+++ b/mix.exs
@@ -57,6 +57,7 @@ defmodule Spandex.Mixfile do
 
   defp deps do
     [
+      {:benchee, "~> 0.13.2", only: [:dev, :test]},
       {:credo, "~> 0.9.2", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:excoveralls, "~> 0.6", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,9 @@
 %{
-  "benchee": {:hex, :benchee, "0.9.0", "433d946b0e4755e186fe564568ead4f593b0d15337fcffa95ed7d5b8a6612670", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, optional: false]}]},
+  "benchee": {:hex, :benchee, "0.13.2", "30cd4ff5f593fdd218a9b26f3c24d580274f297d88ad43383afe525b1543b165", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
   "credo": {:hex, :credo, "0.9.2", "841d316612f568beb22ba310d816353dddf31c2d94aa488ae5a27bb53760d0bf", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
-  "deep_merge": {:hex, :deep_merge, "0.1.1", "c27866a7524a337b6a039eeb8dd4f17d458fd40fbbcb8c54661b71a22fffe846", [:mix], []},
+  "deep_merge": {:hex, :deep_merge, "0.2.0", "c1050fa2edf4848b9f556fba1b75afc66608a4219659e3311d9c9427b5b680b3", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},


### PR DESCRIPTION
This is an initial stab at adding [Benchee](https://github.com/PragTob/benchee) benchmarks for the `Spandex.Plug.*` modules to get a feel for how much performance impact there is when adding Spandex to a service. It is important to note that since the `BaselineRouter` doesn't really do anything, the `x slower` metrics are meaningless, so we should focus on the raw per-request timing increases due to adding tracing (in terms of how many microseconds is tracing adding to each request we process).

I wanted to get this in place so that I can work on an implementation for trace sampling (hence the stubbed-in `inputs` list) and validate that it alleviates the performance overhead of tracing, at least on average, when only sampling a small fraction of requests.

Feedback welcome!

Some initial results from my laptop (with a million other things running, so take it with a grain of salt):

```
Operating System: macOS"
CPU Information: Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
Number of Available Cores: 8
Available memory: 16 GB
Elixir 1.6.6
Erlang 20.3.8.1

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
parallel: 4
inputs: no_sampling
Estimated total run time: 42 s


Benchmarking addcontext with input no_sampling...
Benchmarking baseline with input no_sampling...
Benchmarking start_finish with input no_sampling...

##### With input no_sampling #####
Name                   ips        average  deviation         median         99th %
baseline           49.04 K       20.39 μs    ±82.41%          18 μs          44 μs
start_finish        5.62 K      178.03 μs    ±45.97%         168 μs         427 μs
addcontext          4.74 K      210.96 μs    ±73.94%         185 μs      771.44 μs

Comparison:
baseline           49.04 K
start_finish        5.62 K - 8.73x slower
addcontext          4.74 K - 10.35x slower

Memory usage statistics:

Name                 average  deviation         median         99th %
baseline             3.81 KB     ±0.00%        3.81 KB        3.81 KB
start_finish        24.76 KB     ±0.02%       24.77 KB       24.77 KB
addcontext          33.67 KB     ±0.02%       33.67 KB       33.67 KB

Comparison:
baseline             3.81 KB
start_finish        24.77 KB - 6.50x memory usage
addcontext          33.67 KB - 8.83x memory usage
```