### PR TITLE
Stop overriding completion_time when finishing span

### DIFF
--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -165,9 +165,7 @@ defmodule Spandex do
   end
 
   defp ensure_completion_time_set(%Span{completion_time: nil} = span, adapter) do
-    span
-    |> update_or_keep(completion_time: adapter.now())
-    |> ensure_completion_time_set(adapter)
+    update_or_keep(span, completion_time: adapter.now())
   end
 
   defp ensure_completion_time_set(%Span{} = span, _adapter), do: span

--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -131,7 +131,7 @@ defmodule Spandex do
         {:error, :no_trace_context}
 
       %Trace{spans: spans, stack: stack} ->
-        unfinished_spans = Enum.map(stack, &update_or_keep(&1, completion_time: adapter.now()))
+        unfinished_spans = Enum.map(stack, &ensure_completion_time_set(&1, adapter))
 
         sender = opts[:sender] || adapter.default_sender()
 

--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -164,11 +164,13 @@ defmodule Spandex do
     end
   end
 
-  defp ensure_completion_time_set(span = %Span{completion_time: nil}, adapter) do
-    update_or_keep(span, completion_time: adapter.now()) |> ensure_completion_time_set(adapter)
+  defp ensure_completion_time_set(%Span{completion_time: nil} = span, adapter) do
+    span
+    |> update_or_keep(completion_time: adapter.now())
+    |> ensure_completion_time_set(adapter)
   end
 
-  defp ensure_completion_time_set(span = %Span{}, _adapter), do: span
+  defp ensure_completion_time_set(%Span{} = span, _adapter), do: span
 
   def span_error(_error, _stacktrace, :disabled), do: {:error, :disabled}
 

--- a/test/span_test.exs
+++ b/test/span_test.exs
@@ -25,4 +25,13 @@ defmodule Spandex.Test.SpanTest do
     span = Util.find_span("my_trace")
     assert(span.completion_time == completion_time)
   end
+
+  test "unfinished spans should have a completion time after trace finishes" do
+    Tracer.start_trace("my_trace")
+    Tracer.update_span(service: :my_app, type: :web)
+    Tracer.finish_trace()
+    span = Util.find_span("my_trace")
+
+    assert(span.completion_time != nil)
+  end
 end

--- a/test/span_test.exs
+++ b/test/span_test.exs
@@ -14,4 +14,15 @@ defmodule Spandex.Test.SpanTest do
 
     assert(span.service == :special_service)
   end
+
+  test "finishing a span does not override the completion time" do
+    completion_time = :os.system_time(:nano_seconds)
+    Tracer.start_trace("my_trace")
+    Tracer.update_span(service: :my_app, type: :web, completion_time: completion_time)
+    Tracer.finish_span()
+    Tracer.finish_trace()
+
+    span = Util.find_span("my_trace")
+    assert(span.completion_time == completion_time)
+  end
 end


### PR DESCRIPTION
This should solve #55 and allow creating span based on logs.