### PR TITLE
Encode logger metadata as string.

### DIFF
--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -453,7 +453,7 @@ defmodule Spandex do
     adapter = opts[:adapter]
 
     with {:ok, top_span} <- span(name, opts, span_context, adapter) do
-      Logger.metadata(trace_id: span_context.trace_id, span_id: top_span.id)
+      Logger.metadata(trace_id: to_string(span_context.trace_id), span_id: to_string(top_span.id))
 
       trace = %Trace{
         id: span_context.trace_id,
@@ -483,7 +483,7 @@ defmodule Spandex do
 
     with {:ok, span} <- Span.child_of(current_span, name, adapter.span_id(), adapter.now(), opts),
          {:ok, _trace} <- strategy.put_trace(opts[:trace_key], %{trace | stack: [span | trace.stack]}) do
-      Logger.metadata(span_id: span.id, trace_id: trace.id)
+      Logger.metadata(span_id: to_string(span.id), trace_id: to_string(trace.id))
       {:ok, span}
     end
   end
@@ -495,7 +495,7 @@ defmodule Spandex do
 
     with {:ok, span} <- span(name, opts, span_context, adapter),
          {:ok, _trace} <- strategy.put_trace(opts[:trace_key], %{trace | stack: [span]}) do
-      Logger.metadata(span_id: span.id, trace_id: trace_id)
+      Logger.metadata(span_id: to_string(span.id), trace_id: to_string(trace_id))
       {:ok, span}
     end
   end
@@ -507,7 +507,7 @@ defmodule Spandex do
     span_context = %SpanContext{trace_id: trace_id}
 
     with {:ok, span} <- span(name, opts, span_context, adapter) do
-      Logger.metadata(trace_id: trace_id, span_id: span.id)
+      Logger.metadata(trace_id: to_string(trace_id), span_id: to_string(span.id))
       trace = %Trace{spans: [], stack: [span], id: trace_id}
       strategy.put_trace(opts[:trace_key], trace)
     end

--- a/test/plug/add_context_test.exs
+++ b/test/plug/add_context_test.exs
@@ -50,8 +50,8 @@ defmodule Spandex.Plug.AddContextTest do
 
       assert {:ok, expected_span} = Tracer.start_span("foobar")
 
-      assert Keyword.fetch!(Logger.metadata(), :trace_id) == tid
-      assert Keyword.fetch!(Logger.metadata(), :span_id) == expected_span.id
+      assert Keyword.fetch!(Logger.metadata(), :trace_id) == to_string(tid)
+      assert Keyword.fetch!(Logger.metadata(), :span_id) == to_string(expected_span.id)
 
       {:ok, _} = Tracer.finish_trace()
 


### PR DESCRIPTION
This avoid a potential issue where JSON logs are parsed and numbers are
treated as floats. This can lead to the trace and span ids losing
precision when read from JSON.

If you look at the DataDog docs for other languages, you can see this.
See: https://docs.datadoghq.com/tracing/connect_logs_and_traces/ruby/

Fixes #126 