### PR TITLE
Fix interpolated string span and trace names

### DIFF
--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -31,9 +31,9 @@ defmodule Spandex do
           | {:error, :disabled}
           | {:error, :trace_running}
           | {:error, [Optimal.error()]}
-  def start_trace(_, :disabled), do: {:error, :disabled}
+  def start_trace(name, :disabled) when is_binary(name), do: {:error, :disabled}
 
-  def start_trace(name, opts) do
+  def start_trace(name, opts) when is_binary(name) do
     strategy = opts[:strategy]
 
     if strategy.trace_active?(opts[:trace_key]) do
@@ -55,9 +55,9 @@ defmodule Spandex do
           {:ok, Span.t()}
           | {:error, :disabled}
           | {:error, :no_trace_context}
-  def start_span(_, :disabled), do: {:error, :disabled}
+  def start_span(name, :disabled) when is_binary(name), do: {:error, :disabled}
 
-  def start_span(name, opts) do
+  def start_span(name, opts) when is_binary(name) do
     strategy = opts[:strategy]
 
     case strategy.get_trace(opts[:trace_key]) do

--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -119,7 +119,7 @@ defmodule Spandex.Tracer do
       end
 
       @impl Spandex.Tracer
-      defmacro trace(name, opts \\ [], do: body) when is_binary(name) do
+      defmacro trace(name, opts \\ [], do: body) do
         quote do
           opts = unquote(opts)
 
@@ -140,7 +140,7 @@ defmodule Spandex.Tracer do
       end
 
       @impl Spandex.Tracer
-      defmacro span(name, opts \\ [], do: body) when is_binary(name) do
+      defmacro span(name, opts \\ [], do: body) do
         quote do
           opts = unquote(opts)
           name = unquote(name)

--- a/test/span_test.exs
+++ b/test/span_test.exs
@@ -58,33 +58,20 @@ defmodule Spandex.Test.SpanTest do
   end
 
   test "trace names must be strings" do
-    # This is the current desired behaviour
     assert_raise FunctionClauseError,
-                 "no function clause matching in Spandex.Test.Support.Tracer.\"MACRO-trace\"/4",
+                 "no function clause matching in Spandex.start_trace/2",
                  fn ->
-                   defmodule WillFail do
-                     def fun do
-                       Tracer.trace name: "trace_name", service: :special_service do
-                         :noop
-                       end
-                     end
+                   Tracer.trace name: "trace_name", service: :special_service do
+                     :noop
                    end
                  end
   end
 
-  test "trace names can be interpolated" do
-    # This is the unintentionally broken behavior I want to fix
+  test "trace names can be interpolated at runtime" do
+    Tracer.trace Enum.join(["trace", "_", "name"]), service: :special_service do
+      :noop
+    end
 
-    assert_raise FunctionClauseError,
-                 "no function clause matching in Spandex.Test.Support.Tracer.trace/3",
-                 fn ->
-                   defmodule WillFail do
-                     def fun do
-                       Tracer.trace Enum.join(["trace", "_", "name"]), service: :special_service do
-                         :noop
-                       end
-                     end
-                   end
-                 end
+    assert Util.find_span("trace_name")
   end
 end

--- a/test/span_test.exs
+++ b/test/span_test.exs
@@ -56,4 +56,35 @@ defmodule Spandex.Test.SpanTest do
 
     assert(span.service == :your_app)
   end
+
+  test "trace names must be strings" do
+    # This is the current desired behaviour
+    assert_raise FunctionClauseError,
+                 "no function clause matching in Spandex.Test.Support.Tracer.\"MACRO-trace\"/4",
+                 fn ->
+                   defmodule WillFail do
+                     def fun do
+                       Tracer.trace name: "trace_name", service: :special_service do
+                         :noop
+                       end
+                     end
+                   end
+                 end
+  end
+
+  test "trace names can be interpolated" do
+    # This is the unintentionally broken behavior I want to fix
+
+    assert_raise FunctionClauseError,
+                 "no function clause matching in Spandex.Test.Support.Tracer.trace/3",
+                 fn ->
+                   defmodule WillFail do
+                     def fun do
+                       Tracer.trace Enum.join(["trace", "_", "name"]), service: :special_service do
+                         :noop
+                       end
+                     end
+                   end
+                 end
+  end
 end


### PR DESCRIPTION
This PR fixes #135 where runtime interpolated strings cannot be passed as arguments to the `Tracer.span` and `Tracer.trace` macros. 

I have moved the guard clauses to `Spandex.start_trace/2` and `Spandex.start_span/2` and added guard clauses to the disabled failure case. This ensures the FunctionClauseError is raised if the macro invocation is ever reached in tests. Though, of course, this isn't as effective at preventing bad arguments as a compile time warning.