### PR TITLE
chore: migrate away from deprecated elixir functions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,5 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 config :git_ops,
   mix_project: Spandex.Mixfile,

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :logger, :console,
   level: :debug,

--- a/lib/decorators.ex
+++ b/lib/decorators.ex
@@ -24,7 +24,7 @@ if Code.ensure_loaded?(Decorator.Define) do
         end
     """
 
-    @tracer Application.get_env(:spandex, :decorators)[:tracer]
+    @tracer Application.compile_env(:spandex, :decorators)[:tracer]
 
     use Decorator.Define, span: 0, span: 1, trace: 0, trace: 1
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Spandex.Mixfile do
     [
       app: :spandex,
       version: @version,
-      elixir: "~> 1.7",
+      elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Hey there!

I just noticed some deprecation warnings in our codebase caused by spandex and decided to try to tackle them.
Since `compile_env` is only available after 1.10 I also bumped the elixir version, but I'm not sure how you'd want to handle that regarding releases, so feel completely free to ignore/close this if it doesn't fit in :D 

Thanks for the great work ❤️ 