### PR TITLE
Introduce a configurable sample rate

### DIFF
--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -503,7 +503,8 @@ defmodule Spandex do
   defp do_start_trace(name, opts) do
     strategy = opts[:strategy]
     adapter = opts[:adapter]
-    priority = calculate_priority(opts[:sample_rate])
+    sample_rate = Keyword.get(opts, :sample_rate, 1.0)
+    priority = calculate_priority(sample_rate)
     trace_id = adapter.trace_id()
     span_context = %SpanContext{trace_id: trace_id}
 
@@ -562,7 +563,6 @@ defmodule Spandex do
 
   defp calculate_priority(sample_rate) do
     cond do
-      sample_rate == nil -> 1
       sample_rate == 0 -> 0
       sample_rate == 1 -> 1
       :rand.uniform() <= sample_rate -> 1

--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -51,6 +51,7 @@ defmodule Spandex.Tracer do
                    service: :atom,
                    disabled?: :boolean,
                    env: :string,
+                   sample_rate: :float,
                    service_version: :string,
                    services: {:keyword, :atom},
                    strategy: :atom,
@@ -61,7 +62,8 @@ defmodule Spandex.Tracer do
                  defaults: [
                    disabled?: false,
                    services: [],
-                   strategy: Spandex.Strategy.Pdict
+                   strategy: Spandex.Strategy.Pdict,
+                   sample_rate: 1
                  ],
                  describe: [
                    adapter: "The third party adapter to use",
@@ -73,7 +75,8 @@ defmodule Spandex.Tracer do
                    disabled?: "Allows for wholesale disabling a tracer",
                    env: "A name used to identify the environment name, e.g `prod` or `development`",
                    services: "A mapping of service name to the default span types.",
-                   strategy: "The storage and tracing strategy. Currently only supports local process dictionary."
+                   strategy: "The storage and tracing strategy. Currently only supports local process dictionary.",
+                   sample_rate: "The rate at which to sample traces. 1.0 means 100% of traces are sampled."
                  ]
                )
 

--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -63,7 +63,7 @@ defmodule Spandex.Tracer do
                    disabled?: false,
                    services: [],
                    strategy: Spandex.Strategy.Pdict,
-                   sample_rate: 1
+                   sample_rate: 1.0
                  ],
                  describe: [
                    adapter: "The third party adapter to use",

--- a/test/spandex_test.exs
+++ b/test/spandex_test.exs
@@ -60,6 +60,34 @@ defmodule Spandex.Test.SpandexTest do
       assert {:service, "is required"} in validation_errors
     end
 
+    test "sets priority to 1 if no priority is set" do
+      assert {:ok, %Trace{priority: 1}} =
+               Spandex.start_trace("root_span", @base_opts ++ @span_opts ++ [sample_rate: nil])
+    end
+
+    test "sets priority to 1 if priority is set to 100" do
+      assert {:ok, %Trace{priority: 1}} =
+               Spandex.start_trace("root_span", @base_opts ++ @span_opts ++ [sample_rate: 100])
+    end
+
+    test "sets priority to 0 if no priority is set to 0" do
+      assert {:ok, %Trace{priority: 0}} = Spandex.start_trace("root_span", @base_opts ++ @span_opts ++ [sample_rate: 0])
+    end
+
+    test "sets priority based on sample rate value" do
+      sample_rate = 0.10
+
+      total_priority =
+        Enum.reduce(1..5000, 0, fn _, acc ->
+          {:ok, trace} = Spandex.start_trace("root_span", @base_opts ++ @span_opts ++ [sample_rate: sample_rate])
+          Spandex.finish_trace(@base_opts)
+          acc + trace.priority
+        end)
+
+      diff = abs(total_priority - 500)
+      assert diff <= 50
+    end
+
     test "adds span_id, trace_id to log metadata" do
       opts = @base_opts ++ @span_opts
 

--- a/test/spandex_test.exs
+++ b/test/spandex_test.exs
@@ -65,9 +65,8 @@ defmodule Spandex.Test.SpandexTest do
                Spandex.start_trace("root_span", @base_opts ++ @span_opts ++ [sample_rate: nil])
     end
 
-    test "sets priority to 1 if priority is set to 100" do
-      assert {:ok, %Trace{priority: 1}} =
-               Spandex.start_trace("root_span", @base_opts ++ @span_opts ++ [sample_rate: 100])
+    test "sets priority to 1 if priority is set to 1" do
+      assert {:ok, %Trace{priority: 1}} = Spandex.start_trace("root_span", @base_opts ++ @span_opts ++ [sample_rate: 1])
     end
 
     test "sets priority to 0 if no priority is set to 0" do


### PR DESCRIPTION
Hello 👋,

The projects where we use Spandex operate at a fairly large scale. A byproduct of this is that it becomes cost prohibitive to send all traces to Datadog. To solve this, we implemented our own Spandex sender that implements a sampling rate to determine trace priority before sending the trace to the Datadog agent.

This works pretty well, but falls apart when we use `continue_trace` to setup distributed tracing between different processes. Since priority is determined at the time of sending the trace, each trace priority is independently determined instead of the decision being made once and passed via trace context.

To solve for this I've added an optional configuration for a sampling rate. This effectively enables head based sampling as described in the Datadog [docs](https://docs.datadoghq.com/tracing/trace_pipeline/ingestion_mechanisms/?tab=java#head-based-sampling).